### PR TITLE
Support expanding {Regions} variable in display string

### DIFF
--- a/source/DuplicateHiderPlugin.cs
+++ b/source/DuplicateHiderPlugin.cs
@@ -1125,7 +1125,7 @@ namespace DuplicateHider
                         expanded = expanded.Replace("{Installed}", game.IsInstalled ? "Installed" : "Not installed");
                         if (expanded.Contains("{Regions}"))
                         {
-                            expanded = expanded.Replace("{Regions}", string.Join(", ", game.Regions.Select(e => e.Name)));
+                            expanded = expanded.Replace("{Regions}", game.Regions != null ? string.Join(", ", game.Regions.Select(e => e.Name)) : "");
                         }
 
                         var type = typeof(Game).GetFields();

--- a/source/DuplicateHiderPlugin.cs
+++ b/source/DuplicateHiderPlugin.cs
@@ -1081,7 +1081,8 @@ namespace DuplicateHider
             var vars = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("Installed", "{'Installed'}"),
-                new KeyValuePair<string, string>("SourceName", "{'SourceName'}")
+                new KeyValuePair<string, string>("SourceName", "{'SourceName'}"),
+                new KeyValuePair<string, string>("Regions", "{'Regions'}")
             };
 
 
@@ -1122,6 +1123,11 @@ namespace DuplicateHider
                     {
                         expanded = expanded.Replace("{Source}", game.GetSourceName());
                         expanded = expanded.Replace("{Installed}", game.IsInstalled ? "Installed" : "Not installed");
+                        if (expanded.Contains("{Regions}"))
+                        {
+                            expanded = expanded.Replace("{Regions}", string.Join(", ", game.Regions.Select(e => e.Name)));
+                        }
+
                         var type = typeof(Game).GetFields();
                         foreach (var field in typeof(Game).GetProperties())
                         {


### PR DESCRIPTION
Adds support for `{Regions}` as a variable in the display string for the "Other Copies" menu. The variable is replaced with a comma-separated list of the names of the game's regions.

![image](https://user-images.githubusercontent.com/13633343/137675995-9c1389ce-69a9-4283-8806-a7c913058f50.png)
