### PR TITLE
Fix references to dependencies

### DIFF
--- a/source/DuplicateHider.csproj
+++ b/source/DuplicateHider.csproj
@@ -34,10 +34,10 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="QuickSearchSDK">
-      <HintPath>..\..\QuickSearch\source\bin\Release\QuickSearchSDK.dll</HintPath>
+      <HintPath>..\..\QuickSearch\source\bin\$(Configuration)\QuickSearchSDK.dll</HintPath>
     </Reference>
     <Reference Include="QuickSearchSDK.Attributes">
-      <HintPath>..\..\QuickSearch\source\bin\Release\QuickSearchSDK.Attributes.dll</HintPath>
+      <HintPath>..\..\QuickSearch\source\bin\$(Configuration)\QuickSearchSDK.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="StartPage.SDK">
       <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\Release\StartPage.SDK.dll</HintPath>

--- a/source/DuplicateHider.csproj
+++ b/source/DuplicateHider.csproj
@@ -40,7 +40,7 @@
       <HintPath>..\..\QuickSearch\source\bin\$(Configuration)\QuickSearchSDK.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="StartPage.SDK">
-      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\Release\StartPage.SDK.dll</HintPath>
+      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\$(Configuration)\net462\StartPage.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
`QuickSearch` expected `Release` build only.
`StartPage.SDK` didn't include the `net462` part and expected `Release` build only.