### PR TITLE
Use NuGet package for StartPage.SDK

### DIFF
--- a/source/DuplicateHider.csproj
+++ b/source/DuplicateHider.csproj
@@ -34,10 +34,10 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="QuickSearchSDK">
-      <HintPath>..\..\QuickSearch\source\bin\Release\QuickSearchSDK.dll</HintPath>
+      <HintPath>..\..\QuickSearch\source\bin\$(Configuration)\QuickSearchSDK.dll</HintPath>
     </Reference>
     <Reference Include="QuickSearchSDK.Attributes">
-      <HintPath>..\..\QuickSearch\source\bin\Release\QuickSearchSDK.Attributes.dll</HintPath>
+      <HintPath>..\..\QuickSearch\source\bin\$(Configuration)\QuickSearchSDK.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="StartPage.SDK">
       <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\Release\StartPage.SDK.dll</HintPath>

--- a/source/DuplicateHider.csproj
+++ b/source/DuplicateHider.csproj
@@ -40,7 +40,7 @@
       <HintPath>..\..\QuickSearch\source\bin\$(Configuration)\QuickSearchSDK.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="StartPage.SDK">
-      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\Release\StartPage.SDK.dll</HintPath>
+      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\$(Configuration)\net462\StartPage.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/source/DuplicateHider.csproj
+++ b/source/DuplicateHider.csproj
@@ -39,9 +39,6 @@
     <Reference Include="QuickSearchSDK.Attributes">
       <HintPath>..\..\QuickSearch\source\bin\$(Configuration)\QuickSearchSDK.Attributes.dll</HintPath>
     </Reference>
-    <Reference Include="StartPage.SDK">
-      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\$(Configuration)\net462\StartPage.SDK.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -226,6 +223,9 @@
     </PackageReference>
     <PackageReference Include="PlayniteSDK">
       <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="StartPage.SDK">
+      <Version>1.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
I created a second pull request for the change to NuGet package because I don't know if you prefer to keep the local reference for StartPage.SDK or use the NuGet reference.

This pull request incorporates the fix of the QuickSearchSDK reference too.