### PR TITLE
Fix typo

### DIFF
--- a/source/DuplicateHiderPlugin.cs
+++ b/source/DuplicateHiderPlugin.cs
@@ -290,7 +290,7 @@ namespace DuplicateHider
                 iconWatcher.EnableRaisingEvents = true;
             }
 
-            // Clean orphaned entries from Priorites list
+            // Clean orphaned entries from Priorities list
             for (int i = settings.Priorities.Count - 1; i >= 0; --i)
             {
                 var prio = settings.Priorities[i];

--- a/source/DuplicateHiderSettings.cs
+++ b/source/DuplicateHiderSettings.cs
@@ -626,21 +626,21 @@ namespace DuplicateHider
                     }
                 }
 
-                UniqueList<string> updatedPriorites = new UniqueList<string> { };
+                UniqueList<string> updatedPriorities = new UniqueList<string> { };
                 {
                     foreach (ListBoxItem item in plugin.SettingsView.PriorityListBox.Items)
                     {
                         if (item.Tag is GameSource source)
                         {
-                            updatedPriorites.AddMissing(source.Name);
+                            updatedPriorities.AddMissing(source.Name);
                         }
                         else
                         {
-                            updatedPriorites.AddMissing(Constants.UNDEFINED_SOURCE);
+                            updatedPriorities.AddMissing(Constants.UNDEFINED_SOURCE);
                         }
                     }
                 }
-                Priorities = updatedPriorites;
+                Priorities = updatedPriorities;
                 {
                     foreach (CheckBox cb in plugin.SettingsView.PlatformComboBox.Items)
                     {

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -40,7 +40,7 @@ Click &quot;{0}&quot; to continue or &quot;{1}&quot; to cancel this operation.</
     <sys:String x:Key="LOC_DH_GameFields">Game Fields</sys:String>
     <sys:String x:Key="LOC_DH_SourceGames">Source Games</sys:String>
     <sys:String x:Key="LOC_DH_Warning">Warning</sys:String>
-	<sys:String x:Key="LOC_DH_Priorities">Priorites</sys:String>
+	<sys:String x:Key="LOC_DH_Priorities">Priorities</sys:String>
 	<sys:String x:Key="LOC_DH_AutomaticUpdate">Update Automatically</sys:String>
 	<sys:String x:Key="LOC_DH_ShowOtherCopies">Show Copies in Game Menu</sys:String>
 	<sys:String x:Key="LOC_DH_PrioritizeNewerGames">Prioritize newer Game from same source</sys:String>

--- a/source/Localization/loc_source.xaml
+++ b/source/Localization/loc_source.xaml
@@ -40,7 +40,7 @@ Click "{0}" to continue or "{1}" to cancel this operation.</sys:String>
     <sys:String x:Key="LOC_DH_GameFields">Game Fields</sys:String>
     <sys:String x:Key="LOC_DH_SourceGames">Source Games</sys:String>
     <sys:String x:Key="LOC_DH_Warning">Warning</sys:String>
-	<sys:String x:Key="LOC_DH_Priorities">Priorites</sys:String>
+	<sys:String x:Key="LOC_DH_Priorities">Priorities</sys:String>
 	<sys:String x:Key="LOC_DH_AutomaticUpdate">Update Automatically</sys:String>
 	<sys:String x:Key="LOC_DH_ShowOtherCopies">Show Copies in Game Menu</sys:String>
 	<sys:String x:Key="LOC_DH_PrioritizeNewerGames">Prioritize newer Game from same source</sys:String>


### PR DESCRIPTION
Fixed a typo which changed "priorities" to "priorites". I used the built-in renaming tool in Visual Studio for `updatedPriorities`, so this shouldn't give any errors.